### PR TITLE
Revisions

### DIFF
--- a/data-hub-api/apps/core/models.py
+++ b/data-hub-api/apps/core/models.py
@@ -1,5 +1,7 @@
 from migrator.models import CDMSModel
 
+from reversion import revisions as reversion
+
 
 class CRMBaseModel(CDMSModel):
     """
@@ -11,3 +13,7 @@ class CRMBaseModel(CDMSModel):
     """
     class Meta:
         abstract = True
+
+    @reversion.create_revision()
+    def save(self, *args, **kwargs):
+        return super(CRMBaseModel, self).save(*args, **kwargs)

--- a/data-hub-api/apps/migrator/query.py
+++ b/data-hub-api/apps/migrator/query.py
@@ -18,6 +18,9 @@ from .exceptions import NotMappingFieldException
 from .lookups import FilterNode, Lookup
 
 
+REVISION_COMMENT_CDMS_REFRESH = 'CDMS refresh'
+
+
 class CDMSCompiler(object):
     def __init__(self, query):
         self.query = query
@@ -153,7 +156,9 @@ class CDMSRefreshCompiler(CDMSGetCompiler):
                 update_fields['created'] = obj.created
                 update_fields['cdms_pk'] = obj.cdms_pk
             manager.skip_cdms().filter(pk=obj.pk).update(**update_fields)
-            reversion.default_revision_manager.save_revision([obj])
+            reversion.default_revision_manager.save_revision(
+                [obj], comment=REVISION_COMMENT_CDMS_REFRESH
+            )
 
         return obj
 

--- a/data-hub-api/apps/migrator/tests/base.py
+++ b/data-hub-api/apps/migrator/tests/base.py
@@ -2,7 +2,9 @@ from unittest import mock
 
 from django.test.testcases import TransactionTestCase
 
-from cdms_api.tests.utils import mocked_cdms_get, mocked_cdms_create
+from reversion.models import Revision, Version
+
+from cdms_api.tests.utils import mocked_cdms_get, mocked_cdms_create, mocked_cdms_update
 
 
 class BaseMockedCDMSApiTestCase(TransactionTestCase):
@@ -10,6 +12,7 @@ class BaseMockedCDMSApiTestCase(TransactionTestCase):
     def __call__(self, result, mocked_cdms_api, *args, **kwargs):
         mocked_cdms_api.create.side_effect = mocked_cdms_create()
         mocked_cdms_api.get.side_effect = mocked_cdms_get()
+        mocked_cdms_api.update.side_effect = mocked_cdms_update()
         self.mocked_cdms_api = mocked_cdms_api
         super(BaseMockedCDMSApiTestCase, self).__call__(result, *args, **kwargs)
 
@@ -64,3 +67,13 @@ class BaseMockedCDMSApiTestCase(TransactionTestCase):
 
     def assertAPIDeleteCalled(self, model, kwargs, tot=1):
         self.assertAPICalled(model, 'delete', kwargs=kwargs, tot=tot)
+
+    def assertNoRevisions(self):
+        self.assertEqual(Version.objects.count(), 0)
+        self.assertEqual(Revision.objects.count(), 0)
+
+    def reset_revisions(self):
+        Version.objects.all().delete()
+        Revision.objects.all().delete()
+
+        self.assertNoRevisions()

--- a/data-hub-api/apps/migrator/tests/base.py
+++ b/data-hub-api/apps/migrator/tests/base.py
@@ -4,6 +4,8 @@ from django.test.testcases import TransactionTestCase
 
 from reversion.models import Revision, Version
 
+from migrator.query import REVISION_COMMENT_CDMS_REFRESH
+
 from cdms_api.tests.utils import mocked_cdms_get, mocked_cdms_create, mocked_cdms_update
 
 
@@ -71,6 +73,12 @@ class BaseMockedCDMSApiTestCase(TransactionTestCase):
     def assertNoRevisions(self):
         self.assertEqual(Version.objects.count(), 0)
         self.assertEqual(Revision.objects.count(), 0)
+
+    def assertIsCDMSRefreshRevision(self, revision):
+        self.assertEqual(revision.comment, REVISION_COMMENT_CDMS_REFRESH)
+
+    def assertIsNotCDMSRefreshRevision(self, revision):
+        self.assertNotEqual(revision.comment, REVISION_COMMENT_CDMS_REFRESH)
 
     def reset_revisions(self):
         Version.objects.all().delete()

--- a/data-hub-api/apps/migrator/tests/models.py
+++ b/data-hub-api/apps/migrator/tests/models.py
@@ -1,4 +1,6 @@
 from django.db import models
+from reversion import revisions as reversion
+
 from migrator.models import CDMSModel
 from migrator.managers import CDMSManager
 from migrator.cdms_migrator import BaseCDMSMigrator
@@ -19,6 +21,7 @@ class ParentObjMigrator(BaseCDMSMigrator):
     service = 'Parent'
 
 
+@reversion.register()
 class ParentObj(CDMSModel):
     name = models.CharField(max_length=250)
 
@@ -39,6 +42,7 @@ class SimpleMigrator(BaseCDMSMigrator):
     service = 'Simple'
 
 
+@reversion.register()
 class SimpleObj(CDMSModel):
     name = models.CharField(max_length=250)
     dt_field = models.DateTimeField(null=True)

--- a/data-hub-api/apps/migrator/tests/queries/test_all.py
+++ b/data-hub-api/apps/migrator/tests/queries/test_all.py
@@ -108,6 +108,7 @@ class AllTestCase(BaseMockedCDMSApiTestCase):
         self.assertEqual(len(version_list_obj1), 1)
         version = version_list_obj1[0]
         version_data = version.field_dict
+        self.assertIsCDMSRefreshRevision(version.revision)
         self.assertEqual(version_data['cdms_pk'], obj1.cdms_pk)
         self.assertEqual(version_data['modified'], obj1.modified)
         self.assertEqual(version_data['created'], obj1.created)
@@ -117,6 +118,7 @@ class AllTestCase(BaseMockedCDMSApiTestCase):
         self.assertEqual(len(version_list_obj3), 1)
         version = version_list_obj3[0]
         version_data = version.field_dict
+        self.assertIsCDMSRefreshRevision(version.revision)
         self.assertEqual(version_data['cdms_pk'], obj3.cdms_pk)
         self.assertEqual(version_data['modified'], obj3.modified)
         self.assertEqual(version_data['created'], obj3.created)

--- a/data-hub-api/apps/migrator/tests/queries/test_all.py
+++ b/data-hub-api/apps/migrator/tests/queries/test_all.py
@@ -2,8 +2,11 @@ import datetime
 
 from django.utils import timezone
 
-from migrator.tests.queries.models import SimpleObj
-from migrator.tests.queries.base import BaseMockedCDMSApiTestCase
+from reversion import revisions as reversion
+from reversion.models import Revision, Version
+
+from migrator.tests.models import SimpleObj
+from migrator.tests.base import BaseMockedCDMSApiTestCase
 
 from cdms_api.tests.utils import mocked_cdms_list
 
@@ -17,9 +20,15 @@ class AllTestCase(BaseMockedCDMSApiTestCase):
             - return local objs
 
         In this case:
-            - cdms-pk1 does not exist in local => local obj should get created
-            - cdms-pk2 is in sync with local obj => local obj should not change
-            - cdms-pk3 is more up-to-date than local => local obj should get updated
+            - cdms-pk1 does not exist in local =>
+                - local obj should get created
+                - revisions created
+            - cdms-pk2 is in sync with local obj =>
+                - local obj should not change
+                - no revisions should get created
+            - cdms-pk3 is more up-to-date than local =>
+                - local obj should get updated
+                - revisions created
         """
         obj2 = SimpleObj.objects.skip_cdms().create(
             cdms_pk='cdms-pk2', name='name2', int_field=10
@@ -27,6 +36,7 @@ class AllTestCase(BaseMockedCDMSApiTestCase):
         obj3 = SimpleObj.objects.skip_cdms().create(
             cdms_pk='cdms-pk3', name='name3', int_field=20
         )
+        self.reset_revisions()
 
         mocked_list = [
             {
@@ -89,24 +99,46 @@ class AllTestCase(BaseMockedCDMSApiTestCase):
 
         self.assertAPINotCalled(['get', 'create', 'delete', 'update'])
 
+        # check versions
+        self.assertEqual(Version.objects.count(), 2)
+        self.assertEqual(Revision.objects.count(), 2)
+
+        # obj1
+        version_list_obj1 = reversion.get_for_object(obj1)
+        self.assertEqual(len(version_list_obj1), 1)
+        version = version_list_obj1[0]
+        version_data = version.field_dict
+        self.assertEqual(version_data['cdms_pk'], obj1.cdms_pk)
+        self.assertEqual(version_data['modified'], obj1.modified)
+        self.assertEqual(version_data['created'], obj1.created)
+
+        # obj3
+        version_list_obj3 = reversion.get_for_object(obj3)
+        self.assertEqual(len(version_list_obj3), 1)
+        version = version_list_obj3[0]
+        version_data = version.field_dict
+        self.assertEqual(version_data['cdms_pk'], obj3.cdms_pk)
+        self.assertEqual(version_data['modified'], obj3.modified)
+        self.assertEqual(version_data['created'], obj3.created)
+
     def test_exception(self):
         """
         In case of exceptions during cdms calls, the exception gets propagated.
+        No changes or revisions happen.
         """
         self.mocked_cdms_api.list.side_effect = Exception
-        SimpleObj.objects.skip_cdms().create(
-            cdms_pk='cdms-pk2', name='name2'
-        )
 
         self.assertRaises(
             Exception,
             list, SimpleObj.objects.all()
         )
         self.assertAPINotCalled(['get', 'create', 'delete', 'update'])
+        self.assertNoRevisions()
 
     def test_all_skip_cdms(self):
         """
-        Klass.objects.skip_cdms().all() should not hit cdms.
+        Klass.objects.skip_cdms().all() should not hit cdms and should not create any extra revisions.
         """
         list(SimpleObj.objects.skip_cdms().all())
         self.assertNoAPICalled()
+        self.assertNoRevisions()

--- a/data-hub-api/apps/migrator/tests/queries/test_create.py
+++ b/data-hub-api/apps/migrator/tests/queries/test_create.py
@@ -64,6 +64,7 @@ class CreateWithSaveTestCase(BaseMockedCDMSApiTestCase):
         version_list = reversion.get_for_object(obj)
         self.assertEqual(len(version_list), 1)
         version = version_list[0]
+        self.assertIsNotCDMSRefreshRevision(version.revision)
         version_data = version.field_dict
         self.assertEqual(version_data['cdms_pk'], obj.cdms_pk)
         self.assertEqual(version_data['modified'], obj.modified)
@@ -133,6 +134,7 @@ class CreateWithManagerTestCase(BaseMockedCDMSApiTestCase):
         version_list = reversion.get_for_object(obj)
         self.assertEqual(len(version_list), 1)
         version = version_list[0]
+        self.assertIsNotCDMSRefreshRevision(version.revision)
         version_data = version.field_dict
         self.assertEqual(version_data['cdms_pk'], obj.cdms_pk)
         self.assertEqual(version_data['modified'], obj.modified)

--- a/data-hub-api/apps/migrator/tests/queries/test_create.py
+++ b/data-hub-api/apps/migrator/tests/queries/test_create.py
@@ -2,16 +2,20 @@ import datetime
 
 from django.utils import timezone
 
+from reversion import revisions as reversion
+from reversion.models import Revision, Version
+
 from cdms_api.tests.utils import mocked_cdms_create
 
-from migrator.tests.queries.models import SimpleObj
-from migrator.tests.queries.base import BaseMockedCDMSApiTestCase
+from migrator.tests.models import SimpleObj
+from migrator.tests.base import BaseMockedCDMSApiTestCase
 
 
 class CreateWithSaveTestCase(BaseMockedCDMSApiTestCase):
     def test_success(self):
         """
         obj.save() should create a new obj in local and cdms if it doesn't exist.
+        The operation should create a revision with the change as well.
         """
         modified_on = (timezone.now() - datetime.timedelta(days=1)).replace(microsecond=0)
         cdms_id = 'brand new id'
@@ -21,6 +25,8 @@ class CreateWithSaveTestCase(BaseMockedCDMSApiTestCase):
                 'ModifiedOn': modified_on
             }
         )
+
+        self.assertNoRevisions()
 
         obj = SimpleObj()
         obj.name = 'simple obj'
@@ -51,9 +57,22 @@ class CreateWithSaveTestCase(BaseMockedCDMSApiTestCase):
         self.assertEqual(obj.cdms_pk, cdms_id)
         self.assertEqual(obj.modified, modified_on)
 
+        # check versions
+        self.assertEqual(Version.objects.count(), 1)
+        self.assertEqual(Revision.objects.count(), 1)
+
+        version_list = reversion.get_for_object(obj)
+        self.assertEqual(len(version_list), 1)
+        version = version_list[0]
+        version_data = version.field_dict
+        self.assertEqual(version_data['cdms_pk'], obj.cdms_pk)
+        self.assertEqual(version_data['modified'], obj.modified)
+        self.assertEqual(version_data['created'], obj.created)
+
     def test_exception_triggers_rollback(self):
         """
-        In case of exceptions during cdms calls, no changes should be reflected in the db.
+        In case of exceptions during cdms calls, no changes should be reflected in the db and no revisions
+        should be created.
         """
         self.mocked_cdms_api.create.side_effect = Exception
 
@@ -65,12 +84,14 @@ class CreateWithSaveTestCase(BaseMockedCDMSApiTestCase):
         self.assertEqual(SimpleObj.objects.skip_cdms().count(), 0)
 
         self.assertAPINotCalled(['list', 'update', 'delete', 'get'])
+        self.assertNoRevisions()
 
 
 class CreateWithManagerTestCase(BaseMockedCDMSApiTestCase):
     def test_success(self):
         """
         MyObject.objects.create() should create a new obj in local and cdms.
+        The operation should create a revision with the change as well.
         """
         modified_on = (timezone.now() - datetime.timedelta(days=1)).replace(microsecond=0)
         cdms_id = 'brand new id'
@@ -105,9 +126,22 @@ class CreateWithManagerTestCase(BaseMockedCDMSApiTestCase):
         self.assertEqual(obj.cdms_pk, cdms_id)
         self.assertEqual(obj.modified, modified_on)
 
+        # check versions
+        self.assertEqual(Version.objects.count(), 1)
+        self.assertEqual(Revision.objects.count(), 1)
+
+        version_list = reversion.get_for_object(obj)
+        self.assertEqual(len(version_list), 1)
+        version = version_list[0]
+        version_data = version.field_dict
+        self.assertEqual(version_data['cdms_pk'], obj.cdms_pk)
+        self.assertEqual(version_data['modified'], obj.modified)
+        self.assertEqual(version_data['created'], obj.created)
+
     def test_exception_triggers_rollback(self):
         """
-        In case of exceptions during cdms calls, no changes should be reflected in the db.
+        In case of exceptions during cdms calls, no changes should be reflected in the db and no revisions
+        should be created.
         """
         self.mocked_cdms_api.create.side_effect = Exception
 
@@ -119,6 +153,7 @@ class CreateWithManagerTestCase(BaseMockedCDMSApiTestCase):
         self.assertEqual(SimpleObj.objects.skip_cdms().count(), 0)
 
         self.assertAPINotCalled(['list', 'update', 'delete', 'get'])
+        self.assertNoRevisions()
 
     def test_with_bulk_create(self):
         """
@@ -134,12 +169,14 @@ class CreateWithManagerTestCase(BaseMockedCDMSApiTestCase):
             ]
         )
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
 
 class CreateWithSaveSkipCDMSTestCase(BaseMockedCDMSApiTestCase):
     def test_success(self):
         """
         When calling obj.save(skip_cdms=True), changes should only happen in local, not in cdms.
+        The operation should create a revision with the change as usual.
         """
         obj = SimpleObj()
         obj.name = 'simple obj'
@@ -152,11 +189,16 @@ class CreateWithSaveSkipCDMSTestCase(BaseMockedCDMSApiTestCase):
 
         self.assertNoAPICalled()
 
+        # check versions
+        self.assertEqual(Version.objects.count(), 1)
+        self.assertEqual(Revision.objects.count(), 1)
+
 
 class CreateWithManagerSkipCDMSTestCase(BaseMockedCDMSApiTestCase):
     def test_with_create(self):
         """
         When calling MyObject.objects.skip_cdms().create(), changes should only happen in local, not in cdms.
+        The operation should create a revision with the change as usual.
         """
         self.assertEqual(SimpleObj.objects.skip_cdms().count(), 0)
         obj = SimpleObj.objects.skip_cdms().create(name='simple obj')
@@ -165,10 +207,16 @@ class CreateWithManagerSkipCDMSTestCase(BaseMockedCDMSApiTestCase):
 
         self.assertNoAPICalled()
 
+        # check versions
+        self.assertEqual(Version.objects.count(), 1)
+        self.assertEqual(Revision.objects.count(), 1)
+
     def test_with_bulk_create(self):
         """
         When calling MyObject.objects.skip_cdms().bulk_create(obj1, obj2), changes should only happen in local,
         not in cdms.
+        The operation does NOT create any revisions as bulk_create is a low level call intended to skip all
+        custom and non custom logic and hit the db directly.
         """
         self.assertEqual(SimpleObj.objects.skip_cdms().count(), 0)
         SimpleObj.objects.skip_cdms().bulk_create([
@@ -177,3 +225,4 @@ class CreateWithManagerSkipCDMSTestCase(BaseMockedCDMSApiTestCase):
         ])
 
         self.assertNoAPICalled()
+        self.assertNoRevisions()  # no revisions as this is a low level call without signals

--- a/data-hub-api/apps/migrator/tests/queries/test_delete.py
+++ b/data-hub-api/apps/migrator/tests/queries/test_delete.py
@@ -1,5 +1,5 @@
-from migrator.tests.queries.models import SimpleObj
-from migrator.tests.queries.base import BaseMockedCDMSApiTestCase
+from migrator.tests.models import SimpleObj
+from migrator.tests.base import BaseMockedCDMSApiTestCase
 
 
 class BaseDeleteTestCase(BaseMockedCDMSApiTestCase):
@@ -8,6 +8,7 @@ class BaseDeleteTestCase(BaseMockedCDMSApiTestCase):
         self.obj = SimpleObj.objects.skip_cdms().create(
             cdms_pk='cdms-pk', name='name'
         )
+        self.reset_revisions()
 
 
 class DeleteTestCase(BaseDeleteTestCase):
@@ -23,6 +24,7 @@ class DeleteTestCase(BaseDeleteTestCase):
             SimpleObj, kwargs={'guid': self.obj.cdms_pk}
         )
         self.assertAPINotCalled(['list', 'update', 'get', 'create'])
+        self.assertNoRevisions()
 
     def test_with_manager(self):
         """
@@ -35,6 +37,7 @@ class DeleteTestCase(BaseDeleteTestCase):
             SimpleObj.objects.filter(name__icontains='name').delete
         )
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
     def test_exception_triggers_rollback(self):
         """
@@ -50,6 +53,7 @@ class DeleteTestCase(BaseDeleteTestCase):
         self.assertEqual(SimpleObj.objects.skip_cdms().count(), 1)
 
         self.assertAPINotCalled(['list', 'update', 'get', 'create'])
+        self.assertNoRevisions()
 
 
 class DeleteSkipCDMSTestCase(BaseDeleteTestCase):
@@ -62,6 +66,7 @@ class DeleteSkipCDMSTestCase(BaseDeleteTestCase):
         self.assertEqual(SimpleObj.objects.skip_cdms().count(), 0)
 
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
     def test_with_manager(self):
         """
@@ -72,3 +77,4 @@ class DeleteSkipCDMSTestCase(BaseDeleteTestCase):
         self.assertEqual(SimpleObj.objects.skip_cdms().count(), 0)
 
         self.assertNoAPICalled()
+        self.assertNoRevisions()

--- a/data-hub-api/apps/migrator/tests/queries/test_extras.py
+++ b/data-hub-api/apps/migrator/tests/queries/test_extras.py
@@ -1,7 +1,9 @@
 from django.db.models import Count
 
-from migrator.tests.queries.models import SimpleObj
-from migrator.tests.queries.base import BaseMockedCDMSApiTestCase
+from migrator.tests.models import SimpleObj
+from migrator.tests.base import BaseMockedCDMSApiTestCase
+
+from reversion.models import Revision, Version
 
 
 class SingleObjMixin(object):
@@ -10,6 +12,7 @@ class SingleObjMixin(object):
         self.obj = SimpleObj.objects.skip_cdms().create(
             cdms_pk='cdms-pk', name='name'
         )
+        self.reset_revisions()
 
 
 class AnnotateTestCase(BaseMockedCDMSApiTestCase):
@@ -19,10 +22,12 @@ class AnnotateTestCase(BaseMockedCDMSApiTestCase):
             SimpleObj.objects.annotate, Count('name')
         )
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
     def test_skip_cdms(self):
         list(SimpleObj.objects.skip_cdms().annotate(Count('name')))
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
 
 class ReverseTestCase(BaseMockedCDMSApiTestCase):
@@ -32,10 +37,12 @@ class ReverseTestCase(BaseMockedCDMSApiTestCase):
             SimpleObj.objects.reverse
         )
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
     def test_skip_cdms(self):
         list(SimpleObj.objects.skip_cdms().reverse())
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
 
 class DistinctTestCase(BaseMockedCDMSApiTestCase):
@@ -45,10 +52,12 @@ class DistinctTestCase(BaseMockedCDMSApiTestCase):
             SimpleObj.objects.distinct
         )
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
     def test_skip_cdms(self):
         list(SimpleObj.objects.skip_cdms().distinct())
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
 
 class ValuesTestCase(BaseMockedCDMSApiTestCase):
@@ -58,10 +67,12 @@ class ValuesTestCase(BaseMockedCDMSApiTestCase):
             SimpleObj.objects.values
         )
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
     def test_skip_cdms(self):
         list(SimpleObj.objects.skip_cdms().values())
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
 
 class ValuesListTestCase(BaseMockedCDMSApiTestCase):
@@ -71,10 +82,12 @@ class ValuesListTestCase(BaseMockedCDMSApiTestCase):
             SimpleObj.objects.values_list
         )
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
     def test_skip_cdms(self):
         list(SimpleObj.objects.skip_cdms().values_list())
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
 
 class DatesTestCase(BaseMockedCDMSApiTestCase):
@@ -84,10 +97,12 @@ class DatesTestCase(BaseMockedCDMSApiTestCase):
             SimpleObj.objects.dates, 'd_field', 'year'
         )
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
     def test_skip_cdms(self):
         list(SimpleObj.objects.skip_cdms().dates('d_field', 'year'))
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
 
 class DatetimesTestCase(BaseMockedCDMSApiTestCase):
@@ -97,10 +112,12 @@ class DatetimesTestCase(BaseMockedCDMSApiTestCase):
             SimpleObj.objects.datetimes, 'd_field', 'year'
         )
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
     def test_skip_cdms(self):
         list(SimpleObj.objects.skip_cdms().datetimes('dt_field', 'year'))
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
 
 class NoneTestCase(BaseMockedCDMSApiTestCase):
@@ -108,10 +125,12 @@ class NoneTestCase(BaseMockedCDMSApiTestCase):
         ret = list(SimpleObj.objects.none())
         self.assertEqual(ret, [])
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
     def test_skip_cdms(self):
         list(SimpleObj.objects.skip_cdms().none())
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
 
 class SelectRelatedTestCase(SingleObjMixin, BaseMockedCDMSApiTestCase):
@@ -121,10 +140,12 @@ class SelectRelatedTestCase(SingleObjMixin, BaseMockedCDMSApiTestCase):
             SimpleObj.objects.select_related
         )
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
     def test_skip_cdms(self):
         SimpleObj.objects.skip_cdms().select_related('fk_obj').get(pk=self.obj.pk)
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
 
 class PrefetchRelatedTestCase(SingleObjMixin, BaseMockedCDMSApiTestCase):
@@ -134,6 +155,7 @@ class PrefetchRelatedTestCase(SingleObjMixin, BaseMockedCDMSApiTestCase):
             SimpleObj.objects.prefetch_related
         )
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
     def test_skip_cdms(self):
         self.assertRaises(
@@ -141,6 +163,7 @@ class PrefetchRelatedTestCase(SingleObjMixin, BaseMockedCDMSApiTestCase):
             SimpleObj.objects.skip_cdms().prefetch_related
         )
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
 
 class ExtraTestCase(BaseMockedCDMSApiTestCase):
@@ -150,10 +173,12 @@ class ExtraTestCase(BaseMockedCDMSApiTestCase):
             SimpleObj.objects.extra, select={'is_recent': "dt_field > '2006-01-01'"}
         )
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
     def test_skip_cdms(self):
         list(SimpleObj.objects.skip_cdms().extra(select={'is_recent': "dt_field > '2006-01-01'"}))
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
 
 class DeferTestCase(BaseMockedCDMSApiTestCase):
@@ -163,10 +188,12 @@ class DeferTestCase(BaseMockedCDMSApiTestCase):
             SimpleObj.objects.defer, 'name'
         )
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
     def test_skip_cdms(self):
         list(SimpleObj.objects.skip_cdms().defer('name'))
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
 
 class OnlyTestCase(BaseMockedCDMSApiTestCase):
@@ -176,23 +203,27 @@ class OnlyTestCase(BaseMockedCDMSApiTestCase):
             SimpleObj.objects.only, 'name'
         )
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
     def test_skip_cdms(self):
         list(SimpleObj.objects.skip_cdms().only('name'))
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
 
 class RawTestCase(BaseMockedCDMSApiTestCase):
     def test(self):
         self.assertRaises(
             NotImplementedError,
-            SimpleObj.objects.raw, 'select * from queries_simpleobj'
+            SimpleObj.objects.raw, 'select * from tests_simpleobj'
         )
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
     def test_skip_cdms(self):
-        list(SimpleObj.objects.skip_cdms().raw('select * from queries_simpleobj'))
+        list(SimpleObj.objects.skip_cdms().raw('select * from tests_simpleobj'))
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
 
 class GetOrCreateTestCase(BaseMockedCDMSApiTestCase):
@@ -202,10 +233,15 @@ class GetOrCreateTestCase(BaseMockedCDMSApiTestCase):
             SimpleObj.objects.get_or_create, name='name', defaults={'int_field': 1}
         )
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
     def test_skip_cdms(self):
         SimpleObj.objects.skip_cdms().get_or_create(name='name', defaults={'int_field': 1})
         self.assertNoAPICalled()
+
+        # check versions
+        self.assertEqual(Version.objects.count(), 1)
+        self.assertEqual(Revision.objects.count(), 1)
 
 
 class UpdateOrCreateTestCase(BaseMockedCDMSApiTestCase):
@@ -215,10 +251,15 @@ class UpdateOrCreateTestCase(BaseMockedCDMSApiTestCase):
             SimpleObj.objects.update_or_create, name='name', defaults={'int_field': 1}
         )
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
     def test_skip_cdms(self):
         SimpleObj.objects.skip_cdms().update_or_create(name='name', defaults={'int_field': 1})
         self.assertNoAPICalled()
+
+        # check versions
+        self.assertEqual(Version.objects.count(), 1)
+        self.assertEqual(Revision.objects.count(), 1)
 
 
 class CountTestCase(BaseMockedCDMSApiTestCase):
@@ -228,10 +269,12 @@ class CountTestCase(BaseMockedCDMSApiTestCase):
             SimpleObj.objects.count
         )
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
     def test_skip_cdms(self):
         SimpleObj.objects.skip_cdms().count()
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
 
 class InBulkTestCase(BaseMockedCDMSApiTestCase):
@@ -241,10 +284,12 @@ class InBulkTestCase(BaseMockedCDMSApiTestCase):
             SimpleObj.objects.in_bulk, [1, 2]
         )
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
     def test_skip_cdms(self):
         SimpleObj.objects.skip_cdms().in_bulk([1, 2])
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
 
 class LatestTestCase(SingleObjMixin, BaseMockedCDMSApiTestCase):
@@ -254,10 +299,12 @@ class LatestTestCase(SingleObjMixin, BaseMockedCDMSApiTestCase):
             SimpleObj.objects.latest, 'dt_field'
         )
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
     def test_skip_cdms(self):
         SimpleObj.objects.skip_cdms().latest('dt_field')
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
 
 class EarliestTestCase(SingleObjMixin, BaseMockedCDMSApiTestCase):
@@ -267,10 +314,12 @@ class EarliestTestCase(SingleObjMixin, BaseMockedCDMSApiTestCase):
             SimpleObj.objects.earliest, 'dt_field'
         )
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
     def test_skip_cdms(self):
         SimpleObj.objects.skip_cdms().earliest('dt_field')
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
 
 class FirstTestCase(SingleObjMixin, BaseMockedCDMSApiTestCase):
@@ -280,10 +329,12 @@ class FirstTestCase(SingleObjMixin, BaseMockedCDMSApiTestCase):
             SimpleObj.objects.first
         )
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
     def test_skip_cdms(self):
         SimpleObj.objects.skip_cdms().first()
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
 
 class LastTestCase(SingleObjMixin, BaseMockedCDMSApiTestCase):
@@ -293,10 +344,12 @@ class LastTestCase(SingleObjMixin, BaseMockedCDMSApiTestCase):
             SimpleObj.objects.last
         )
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
     def test_skip_cdms(self):
         SimpleObj.objects.skip_cdms().last()
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
 
 class AggregateTestCase(BaseMockedCDMSApiTestCase):
@@ -306,10 +359,12 @@ class AggregateTestCase(BaseMockedCDMSApiTestCase):
             SimpleObj.objects.aggregate, Count('name')
         )
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
     def test_skip_cdms(self):
         SimpleObj.objects.skip_cdms().aggregate(Count('name'))
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
 
 class ExistsTestCase(BaseMockedCDMSApiTestCase):
@@ -323,3 +378,4 @@ class ExistsTestCase(BaseMockedCDMSApiTestCase):
     def test_skip_cdms(self):
         SimpleObj.objects.skip_cdms().exists()
         self.assertNoAPICalled()
+        self.assertNoRevisions()

--- a/data-hub-api/apps/migrator/tests/queries/test_filter_exclude.py
+++ b/data-hub-api/apps/migrator/tests/queries/test_filter_exclude.py
@@ -2,8 +2,8 @@ import datetime
 
 from django.db.models import Q
 
-from migrator.tests.queries.models import SimpleObj
-from migrator.tests.queries.base import BaseMockedCDMSApiTestCase
+from migrator.tests.models import SimpleObj
+from migrator.tests.base import BaseMockedCDMSApiTestCase
 
 
 class FilterTestCase(BaseMockedCDMSApiTestCase):
@@ -14,6 +14,7 @@ class FilterTestCase(BaseMockedCDMSApiTestCase):
             SimpleObj, kwargs={'filters': "Name eq 'something'"}
         )
         self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
+        self.assertNoRevisions()
 
     def test_q_one_field(self):
         list(SimpleObj.objects.filter(Q(name='something')))
@@ -22,6 +23,7 @@ class FilterTestCase(BaseMockedCDMSApiTestCase):
             SimpleObj, kwargs={'filters': "Name eq 'something'"}
         )
         self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
+        self.assertNoRevisions()
 
     def test_two_fields(self):
         list(SimpleObj.objects.filter(name='something', int_field=1))
@@ -30,6 +32,7 @@ class FilterTestCase(BaseMockedCDMSApiTestCase):
             SimpleObj, kwargs={'filters': "(IntField eq 1 and Name eq 'something')"}
         )
         self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
+        self.assertNoRevisions()
 
     def test_q_two_fields_in_and(self):
         list(SimpleObj.objects.filter(Q(name='something') & Q(int_field=10)))
@@ -38,6 +41,7 @@ class FilterTestCase(BaseMockedCDMSApiTestCase):
             SimpleObj, kwargs={'filters': "(IntField eq 10 and Name eq 'something')"}
         )
         self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
+        self.assertNoRevisions()
 
     def test_two_fields_in_chain(self):
         list(SimpleObj.objects.filter(name='something').filter(int_field=1))
@@ -46,6 +50,7 @@ class FilterTestCase(BaseMockedCDMSApiTestCase):
             SimpleObj, kwargs={'filters': "(IntField eq 1 and Name eq 'something')"}
         )
         self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
+        self.assertNoRevisions()
 
     def test_two_fields_in_or(self):
         list(SimpleObj.objects.filter(Q(name='something') | Q(int_field=1)))
@@ -55,6 +60,7 @@ class FilterTestCase(BaseMockedCDMSApiTestCase):
         )
 
         self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
+        self.assertNoRevisions()
 
     def test_q_fields_in_and_in_group(self):
         dt = datetime.datetime(2016, 1, 1).replace(tzinfo=datetime.timezone.utc)
@@ -71,6 +77,7 @@ class FilterTestCase(BaseMockedCDMSApiTestCase):
             }
         )
         self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
+        self.assertNoRevisions()
 
     def test_q_fields_in_and__or_in_group(self):
         dt = datetime.datetime(2016, 1, 1).replace(tzinfo=datetime.timezone.utc)
@@ -87,6 +94,7 @@ class FilterTestCase(BaseMockedCDMSApiTestCase):
             }
         )
         self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
+        self.assertNoRevisions()
 
 
 class FilterSkipCDMSTestCase(BaseMockedCDMSApiTestCase):
@@ -96,6 +104,7 @@ class FilterSkipCDMSTestCase(BaseMockedCDMSApiTestCase):
         """
         list(SimpleObj.objects.skip_cdms().filter(name='something'))
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
 
 class ExcludeTestCase(BaseMockedCDMSApiTestCase):
@@ -106,6 +115,7 @@ class ExcludeTestCase(BaseMockedCDMSApiTestCase):
             SimpleObj, kwargs={'filters': "not (Name eq 'something')"}
         )
         self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
+        self.assertNoRevisions()
 
     def test_two_fields(self):
         list(SimpleObj.objects.exclude(name='something', int_field=1))
@@ -114,6 +124,7 @@ class ExcludeTestCase(BaseMockedCDMSApiTestCase):
             SimpleObj, kwargs={'filters': "not (IntField eq 1 and Name eq 'something')"}
         )
         self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
+        self.assertNoRevisions()
 
     def test_two_fields_in_chain(self):
         list(SimpleObj.objects.exclude(name='something').exclude(int_field=1))
@@ -122,6 +133,7 @@ class ExcludeTestCase(BaseMockedCDMSApiTestCase):
             SimpleObj, kwargs={'filters': "(not (IntField eq 1) and not (Name eq 'something'))"}
         )
         self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
+        self.assertNoRevisions()
 
     def test_two_fields_in_or(self):
         list(SimpleObj.objects.exclude(Q(name='something') | Q(int_field=1)))
@@ -130,6 +142,7 @@ class ExcludeTestCase(BaseMockedCDMSApiTestCase):
             SimpleObj, kwargs={'filters': "not ((IntField eq 1 or Name eq 'something'))"}
         )
         self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
+        self.assertNoRevisions()
 
     def test_simple_filter_exclude(self):
         list(SimpleObj.objects.filter(name='something').exclude(int_field=1))
@@ -138,6 +151,7 @@ class ExcludeTestCase(BaseMockedCDMSApiTestCase):
             SimpleObj, kwargs={'filters': "(Name eq 'something' and not (IntField eq 1))"}
         )
         self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
+        self.assertNoRevisions()
 
     def test_complex_filter_exclude(self):
         list(
@@ -155,6 +169,7 @@ class ExcludeTestCase(BaseMockedCDMSApiTestCase):
             }
         )
         self.assertAPINotCalled(['create', 'update', 'delete', 'get'])
+        self.assertNoRevisions()
 
 
 class ExcludeSkipCDMSTestCase(BaseMockedCDMSApiTestCase):
@@ -164,3 +179,4 @@ class ExcludeSkipCDMSTestCase(BaseMockedCDMSApiTestCase):
     def test_exclude(self):
         list(SimpleObj.objects.skip_cdms().exclude(name='something'))
         self.assertNoAPICalled()
+        self.assertNoRevisions()

--- a/data-hub-api/apps/migrator/tests/queries/test_filter_lookups.py
+++ b/data-hub-api/apps/migrator/tests/queries/test_filter_lookups.py
@@ -2,8 +2,8 @@ from unittest import skip
 
 from django.utils import timezone
 
-from migrator.tests.queries.models import SimpleObj
-from migrator.tests.queries.base import BaseMockedCDMSApiTestCase
+from migrator.tests.models import SimpleObj
+from migrator.tests.base import BaseMockedCDMSApiTestCase
 
 
 class FilterLookupsTestCase(BaseMockedCDMSApiTestCase):

--- a/data-hub-api/apps/migrator/tests/queries/test_foreign_key.py
+++ b/data-hub-api/apps/migrator/tests/queries/test_foreign_key.py
@@ -5,8 +5,8 @@ from cdms_api.tests.utils import mocked_cdms_create
 
 from migrator.exceptions import NotMappingFieldException
 
-from migrator.tests.queries.models import SimpleObj, ParentObj
-from migrator.tests.queries.base import BaseMockedCDMSApiTestCase
+from migrator.tests.models import SimpleObj, ParentObj
+from migrator.tests.base import BaseMockedCDMSApiTestCase
 
 
 class BaseForeignKeyTestCase(BaseMockedCDMSApiTestCase):

--- a/data-hub-api/apps/migrator/tests/queries/test_get.py
+++ b/data-hub-api/apps/migrator/tests/queries/test_get.py
@@ -3,10 +3,13 @@ import datetime
 from django.utils import timezone
 from django.core.exceptions import MultipleObjectsReturned
 
+from reversion import revisions as reversion
+from reversion.models import Revision, Version
+
 from cdms_api.exceptions import CDMSNotFoundException
 
-from migrator.tests.queries.models import SimpleObj
-from migrator.tests.queries.base import BaseMockedCDMSApiTestCase
+from migrator.tests.models import SimpleObj
+from migrator.tests.base import BaseMockedCDMSApiTestCase
 from migrator.exceptions import ObjectsNotInSyncException
 
 from cdms_api.tests.utils import mocked_cdms_get
@@ -18,6 +21,7 @@ class BaseGetTestCase(BaseMockedCDMSApiTestCase):
         self.obj = SimpleObj.objects.skip_cdms().create(
             cdms_pk='cdms-pk', name='name'
         )
+        self.reset_revisions()
 
 
 class GetByIdTestCase(BaseGetTestCase):
@@ -32,6 +36,7 @@ class GetByIdTestCase(BaseGetTestCase):
             SimpleObj, kwargs={'guid': self.obj.cdms_pk}
         )
         self.assertAPINotCalled(['list', 'update', 'delete', 'create'])
+        self.assertNoRevisions()
 
     def test_local_doesnt_exist(self):
         """
@@ -44,6 +49,7 @@ class GetByIdTestCase(BaseGetTestCase):
         )
 
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
 
 class GetByCmdPKTestCase(BaseGetTestCase):
@@ -51,6 +57,7 @@ class GetByCmdPKTestCase(BaseGetTestCase):
         """
         MyObject.objects.get(cdms_pk=..) when local obj exists,
         should hit the cdms api and return the local obj.
+        The operation does not create any revisions.
         """
         obj = SimpleObj.objects.get(cdms_pk=self.obj.cdms_pk)
         self.assertEqual(obj.pk, self.obj.pk)
@@ -59,11 +66,13 @@ class GetByCmdPKTestCase(BaseGetTestCase):
             SimpleObj, kwargs={'guid': self.obj.cdms_pk}
         )
         self.assertAPINotCalled(['list', 'update', 'delete', 'create'])
+        self.assertNoRevisions()
 
     def test_local_doesnt_exist(self):
         """
         MyObject.objects.get(cdms_pk=..) when local obj does not exist,
         should hit the cdms api, create a local obj and return it.
+        The operation should create a revision.
         """
         modified_on = (timezone.now() + datetime.timedelta(days=1)).replace(microsecond=0)
         self.mocked_cdms_api.get.side_effect = mocked_cdms_get(
@@ -96,6 +105,18 @@ class GetByCmdPKTestCase(BaseGetTestCase):
         self.assertEqual(obj.name, 'new name')
         self.assertEqual(obj.modified, modified_on)
 
+        # check versions
+        self.assertEqual(Version.objects.count(), 1)
+        self.assertEqual(Revision.objects.count(), 1)
+
+        version_list_obj = reversion.get_for_object(obj)
+        self.assertEqual(len(version_list_obj), 1)
+        version = version_list_obj[0]
+        version_data = version.field_dict
+        self.assertEqual(version_data['cdms_pk'], obj.cdms_pk)
+        self.assertEqual(version_data['modified'], obj.modified)
+        self.assertEqual(version_data['created'], obj.created)
+
     def test_neither_local_nor_cdms_obj_exists(self):
         """
         MyObject.objects.get(cdms_pk=..) when neither local nor cdms obj exists
@@ -116,6 +137,7 @@ class GetByCmdPKTestCase(BaseGetTestCase):
             SimpleObj, kwargs={'guid': 'cdms-pk'}
         )
         self.assertAPINotCalled(['list', 'update', 'delete', 'create'])
+        self.assertNoRevisions()
 
 
 class GetByOtherFieldsTestCase(BaseGetTestCase):
@@ -130,10 +152,12 @@ class GetByOtherFieldsTestCase(BaseGetTestCase):
             SimpleObj, kwargs={'guid': self.obj.cdms_pk}
         )
         self.assertAPINotCalled(['list', 'update', 'delete', 'create'])
+        self.assertNoRevisions()
 
     def test_multiple_objects_returned(self):
         SimpleObj.objects.skip_cdms().create(cdms_pk='cdms-pk1', name='name')
         SimpleObj.objects.skip_cdms().create(cdms_pk='cdms-pk2', name='name')
+        self.reset_revisions()
 
         self.assertRaises(
             MultipleObjectsReturned,
@@ -142,6 +166,7 @@ class GetByOtherFieldsTestCase(BaseGetTestCase):
         )
 
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
 
 class SyncGetTestCase(BaseGetTestCase):
@@ -151,6 +176,7 @@ class SyncGetTestCase(BaseGetTestCase):
             - get obj from local db
             - get cdms_obj from cdms
             - no local changes happen
+            - no extra revision created
         """
         self.mocked_cdms_api.get.side_effect = mocked_cdms_get(
             get_data={
@@ -166,11 +192,13 @@ class SyncGetTestCase(BaseGetTestCase):
         )
 
         self.assertAPINotCalled(['list', 'update', 'delete', 'create'])
+        self.assertNoRevisions()
 
     def test_with_local_more_up_to_date(self):
         """
         If the local obj is more up to date, it means that the last syncronisation didn't
         work as it should have, so we raise ObjectsNotInSyncException.
+        The operation should not create any revisions.
         """
         modified_on = self.obj.modified - datetime.timedelta(seconds=0.001)
 
@@ -189,6 +217,7 @@ class SyncGetTestCase(BaseGetTestCase):
         )
 
         self.assertAPINotCalled(['list', 'update', 'delete', 'create'])
+        self.assertNoRevisions()
 
     def test_with_cdms_more_up_to_date(self):
         """
@@ -196,6 +225,7 @@ class SyncGetTestCase(BaseGetTestCase):
             - get obj from local db
             - get cdms_obj from cdms
             - update obj from cdms_obj
+            - create a revision
         """
         modified_on = self.obj.modified + datetime.timedelta(seconds=1)
         self.mocked_cdms_api.get.side_effect = mocked_cdms_get(
@@ -227,6 +257,18 @@ class SyncGetTestCase(BaseGetTestCase):
         self.assertEqual(obj.name, 'new name')
         self.assertEqual(obj.modified, modified_on)
 
+        # check versions
+        self.assertEqual(Version.objects.count(), 1)
+        self.assertEqual(Revision.objects.count(), 1)
+
+        version_list = reversion.get_for_object(obj)
+        self.assertEqual(len(version_list), 1)
+        version = version_list[0]
+        version_data = version.field_dict
+        self.assertEqual(version_data['cdms_pk'], obj.cdms_pk)
+        self.assertEqual(version_data['modified'], obj.modified)
+        self.assertEqual(version_data['created'], obj.created)
+
     def test_cdms_exception_triggers_exception(self):
         """
         If an exception happens when accessing cdms, the exception is propagated.
@@ -236,22 +278,25 @@ class SyncGetTestCase(BaseGetTestCase):
         self.assertRaises(
             Exception, SimpleObj.objects.get, pk=self.obj.pk
         )
+        self.assertNoRevisions()
 
 
 class GetSkipCDMSTestCase(BaseGetTestCase):
     def test_get_by_any_fields(self):
         """
-        Klass.objects.skip_cdms().get(...) should not hit cdms.
+        Klass.objects.skip_cdms().get(...) should not hit cdms and should not create any revisions.
         """
         SimpleObj.objects.skip_cdms().get(pk=self.obj.pk)
         self.assertNoAPICalled()
 
         SimpleObj.objects.skip_cdms().get(cdms_pk=self.obj.cdms_pk)
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
     def test_object_not_found(self):
         """
-        Klass.objects.skip_cdms().get(...) should raise DoesNotExist and not hit cdms.
+        Klass.objects.skip_cdms().get(...) should raise DoesNotExist, should not hit cdms
+        and should not create any revisions.
         """
         self.assertRaises(
             SimpleObj.DoesNotExist,
@@ -259,3 +304,4 @@ class GetSkipCDMSTestCase(BaseGetTestCase):
             cdms_pk='invalid'
         )
         self.assertNoAPICalled()
+        self.assertNoRevisions()

--- a/data-hub-api/apps/migrator/tests/queries/test_get.py
+++ b/data-hub-api/apps/migrator/tests/queries/test_get.py
@@ -112,6 +112,7 @@ class GetByCmdPKTestCase(BaseGetTestCase):
         version_list_obj = reversion.get_for_object(obj)
         self.assertEqual(len(version_list_obj), 1)
         version = version_list_obj[0]
+        self.assertIsCDMSRefreshRevision(version.revision)
         version_data = version.field_dict
         self.assertEqual(version_data['cdms_pk'], obj.cdms_pk)
         self.assertEqual(version_data['modified'], obj.modified)
@@ -264,6 +265,7 @@ class SyncGetTestCase(BaseGetTestCase):
         version_list = reversion.get_for_object(obj)
         self.assertEqual(len(version_list), 1)
         version = version_list[0]
+        self.assertIsCDMSRefreshRevision(version.revision)
         version_data = version.field_dict
         self.assertEqual(version_data['cdms_pk'], obj.cdms_pk)
         self.assertEqual(version_data['modified'], obj.modified)

--- a/data-hub-api/apps/migrator/tests/queries/test_order_by.py
+++ b/data-hub-api/apps/migrator/tests/queries/test_order_by.py
@@ -1,5 +1,5 @@
-from migrator.tests.queries.models import SimpleObj
-from migrator.tests.queries.base import BaseMockedCDMSApiTestCase
+from migrator.tests.models import SimpleObj
+from migrator.tests.base import BaseMockedCDMSApiTestCase
 
 
 class OrderByTestCase(BaseMockedCDMSApiTestCase):
@@ -17,6 +17,7 @@ class OrderByTestCase(BaseMockedCDMSApiTestCase):
             }
         )
         self.assertAPINotCalled(['get', 'create', 'delete', 'update'])
+        self.assertNoRevisions()
 
     def test_order_by_name_asc(self):
         """
@@ -34,6 +35,7 @@ class OrderByTestCase(BaseMockedCDMSApiTestCase):
             }
         )
         self.assertAPINotCalled(['get', 'create', 'delete', 'update'])
+        self.assertNoRevisions()
 
     def test_order_by_name_desc(self):
         """
@@ -51,6 +53,7 @@ class OrderByTestCase(BaseMockedCDMSApiTestCase):
             }
         )
         self.assertAPINotCalled(['get', 'create', 'delete', 'update'])
+        self.assertNoRevisions()
 
     def test_order_by_two_fields(self):
         """
@@ -69,6 +72,7 @@ class OrderByTestCase(BaseMockedCDMSApiTestCase):
             }
         )
         self.assertAPINotCalled(['get', 'create', 'delete', 'update'])
+        self.assertNoRevisions()
 
     def test_order_by_non_cdms_field(self):
         """
@@ -82,6 +86,7 @@ class OrderByTestCase(BaseMockedCDMSApiTestCase):
         )
 
         self.assertAPINotCalled(['get', 'create', 'delete', 'update'])
+        self.assertNoRevisions()
 
     def test_order_randomly(self):
         """
@@ -94,6 +99,7 @@ class OrderByTestCase(BaseMockedCDMSApiTestCase):
         )
 
         self.assertAPINotCalled(['get', 'create', 'delete', 'update'])
+        self.assertNoRevisions()
 
     def test_order_by_related_obj_field(self):
         """
@@ -109,6 +115,7 @@ class OrderByTestCase(BaseMockedCDMSApiTestCase):
             }
         )
         self.assertAPINotCalled(['get', 'create', 'delete', 'update'])
+        self.assertNoRevisions()
 
 
 class OrderBySkipCDMSTestCase(BaseMockedCDMSApiTestCase):
@@ -118,6 +125,7 @@ class OrderBySkipCDMSTestCase(BaseMockedCDMSApiTestCase):
         """
         list(SimpleObj.objects.skip_cdms().all())
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
     def test_order_by_name(self):
         """
@@ -125,6 +133,7 @@ class OrderBySkipCDMSTestCase(BaseMockedCDMSApiTestCase):
         """
         list(SimpleObj.objects.skip_cdms().all().order_by('name'))
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
     def test_order_by_two_fields(self):
         """
@@ -132,6 +141,7 @@ class OrderBySkipCDMSTestCase(BaseMockedCDMSApiTestCase):
         """
         list(SimpleObj.objects.skip_cdms().all().order_by('modified', '-name'))
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
     def test_order_randomly(self):
         """
@@ -139,7 +149,9 @@ class OrderBySkipCDMSTestCase(BaseMockedCDMSApiTestCase):
         """
         list(SimpleObj.objects.skip_cdms().all().order_by('?'))
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
     def test_order_by_related_obj_field(self):
         list(SimpleObj.objects.skip_cdms().all().order_by('fk_obj'))
         self.assertNoAPICalled()
+        self.assertNoRevisions()

--- a/data-hub-api/apps/migrator/tests/queries/test_update.py
+++ b/data-hub-api/apps/migrator/tests/queries/test_update.py
@@ -80,6 +80,7 @@ class UpdateWithSaveTestCase(BaseMockedCDMSApiTestCase):
         version_list = reversion.get_for_object(obj)
         self.assertEqual(len(version_list), 1)
         version = version_list[0]
+        self.assertIsNotCDMSRefreshRevision(version.revision)
         version_data = version.field_dict
         self.assertEqual(version_data['name'], obj.name)
         self.assertEqual(version_data['cdms_pk'], obj.cdms_pk)
@@ -150,6 +151,7 @@ class UpdateWithSaveTestCase(BaseMockedCDMSApiTestCase):
         version_list = reversion.get_for_object(obj)
         self.assertEqual(len(version_list), 1)
         version = version_list[0]
+        self.assertIsNotCDMSRefreshRevision(version.revision)
         version_data = version.field_dict
         self.assertEqual(version_data['name'], obj.name)
         self.assertEqual(version_data['cdms_pk'], obj.cdms_pk)

--- a/data-hub-api/apps/migrator/tests/queries/test_update.py
+++ b/data-hub-api/apps/migrator/tests/queries/test_update.py
@@ -3,8 +3,11 @@ import datetime
 from django.db import transaction
 from django.utils import timezone
 
-from migrator.tests.queries.models import SimpleObj
-from migrator.tests.queries.base import BaseMockedCDMSApiTestCase
+from reversion import revisions as reversion
+from reversion.models import Revision, Version
+
+from migrator.tests.models import SimpleObj
+from migrator.tests.base import BaseMockedCDMSApiTestCase
 
 from cdms_api.tests.utils import mocked_cdms_get, mocked_cdms_update
 
@@ -16,7 +19,7 @@ class UpdateWithSaveTestCase(BaseMockedCDMSApiTestCase):
             - get the related cdms obj
             - update the cdms obj
             - save local obj
-
+            - create a revision
 
         This also checks that after the operation, the local_obj.modified has the same value as the cdms modified
         one, NOT the automatic django value. This is important for the syncronisation.
@@ -40,6 +43,7 @@ class UpdateWithSaveTestCase(BaseMockedCDMSApiTestCase):
             cdms_pk='cdms-pk',
             name='old name'
         )
+        self.reset_revisions()
 
         # save
         self.assertEqual(SimpleObj.objects.skip_cdms().count(), 1)
@@ -69,6 +73,19 @@ class UpdateWithSaveTestCase(BaseMockedCDMSApiTestCase):
         )
         self.assertAPINotCalled(['list', 'create', 'delete'])
 
+        # check versions
+        self.assertEqual(Version.objects.count(), 1)
+        self.assertEqual(Revision.objects.count(), 1)
+
+        version_list = reversion.get_for_object(obj)
+        self.assertEqual(len(version_list), 1)
+        version = version_list[0]
+        version_data = version.field_dict
+        self.assertEqual(version_data['name'], obj.name)
+        self.assertEqual(version_data['cdms_pk'], obj.cdms_pk)
+        self.assertEqual(version_data['modified'], obj.modified)
+        self.assertEqual(version_data['created'], obj.created)
+
         # reload obj and check, 'modified' should be == cdms modified
         obj = SimpleObj.objects.skip_cdms().get(pk=obj.pk)
         self.assertEqual(obj.name, 'simple obj')
@@ -87,6 +104,7 @@ class UpdateWithSaveTestCase(BaseMockedCDMSApiTestCase):
             name='old name'
         )
         old_modified = obj.modified
+        self.reset_revisions()
 
         # save
         self.assertEqual(SimpleObj.objects.skip_cdms().count(), 1)
@@ -99,6 +117,7 @@ class UpdateWithSaveTestCase(BaseMockedCDMSApiTestCase):
             SimpleObj, kwargs={'guid': 'cdms-pk'}
         )
         self.assertAPINotCalled(['create', 'list', 'delete'])
+        self.assertNoRevisions()
 
         # check that the obj in the db didn't change
         obj = SimpleObj.objects.skip_cdms().get(pk=obj.pk)
@@ -108,12 +127,14 @@ class UpdateWithSaveTestCase(BaseMockedCDMSApiTestCase):
     def test_save_with_skip_cdms(self):
         """
         obj.save(skip_cdms=True) should only update the obj in local.
+        The operation creates a revision as usual.
         """
         # create without cdms and then save
         obj = SimpleObj.objects.skip_cdms().create(
             cdms_pk='cdms-pk',
             name='old name'
         )
+        self.reset_revisions()
 
         self.assertEqual(SimpleObj.objects.skip_cdms().count(), 1)
         obj.name = 'simple obj'
@@ -121,6 +142,19 @@ class UpdateWithSaveTestCase(BaseMockedCDMSApiTestCase):
         self.assertEqual(SimpleObj.objects.skip_cdms().count(), 1)
 
         self.assertNoAPICalled()
+
+        # check versions
+        self.assertEqual(Version.objects.count(), 1)
+        self.assertEqual(Revision.objects.count(), 1)
+
+        version_list = reversion.get_for_object(obj)
+        self.assertEqual(len(version_list), 1)
+        version = version_list[0]
+        version_data = version.field_dict
+        self.assertEqual(version_data['name'], obj.name)
+        self.assertEqual(version_data['cdms_pk'], obj.cdms_pk)
+        self.assertEqual(version_data['modified'], obj.modified)
+        self.assertEqual(version_data['created'], obj.created)
 
         # check that the obj in the db changed
         obj = SimpleObj.objects.skip_cdms().get(pk=obj.pk)
@@ -133,6 +167,7 @@ class UpdateWithManagerTestCase(BaseMockedCDMSApiTestCase):
         MyObject.objects.filter(...).update(...) not currently implemented
         """
         SimpleObj.objects.skip_cdms().create(cdms_pk='cdms-pk', name='old name')
+        self.reset_revisions()
 
         self.assertRaises(
             NotImplementedError,
@@ -140,22 +175,28 @@ class UpdateWithManagerTestCase(BaseMockedCDMSApiTestCase):
             name='new name'
         )
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
     def test_update_with_skip_cdms(self):
         """
         MyObject.objects.skip_cdms().filter(...).update(...) should only update local objs.
+
+        The operation does not create any revisions as it'a a django low level api
+        which skips all custom and non-custom logic.
         """
         # create without cdms and then save
         obj = SimpleObj.objects.skip_cdms().create(
             cdms_pk='cdms-pk',
             name='old name'
         )
+        self.reset_revisions()
 
         self.assertEqual(SimpleObj.objects.skip_cdms().count(), 1)
         SimpleObj.objects.skip_cdms().filter(pk=obj.pk).update(name='simple obj')
         self.assertEqual(SimpleObj.objects.skip_cdms().count(), 1)
 
         self.assertNoAPICalled()
+        self.assertNoRevisions()
 
         # check that the obj in the db changed
         obj = SimpleObj.objects.skip_cdms().get(pk=obj.pk)
@@ -177,9 +218,11 @@ class SelectForUpdateCDMSTestCase(BaseMockedCDMSApiTestCase):
         MyObject.objects.skip_cdms().select_for_update() should only work on local objs.
         """
         SimpleObj.objects.skip_cdms().create(cdms_pk='cdms-pk', name='old name')
+        self.reset_revisions()
 
         with transaction.atomic():
             entries = SimpleObj.objects.skip_cdms().select_for_update().filter(name__icontains='name')
             self.assertEqual(len(entries), 1)
 
             self.assertNoAPICalled()
+            self.assertNoRevisions()

--- a/data-hub-api/apps/migrator/tests/test_revisions.py
+++ b/data-hub-api/apps/migrator/tests/test_revisions.py
@@ -1,0 +1,112 @@
+from unittest import skip
+
+from reversion import revisions as reversion
+from reversion.models import Revision, Version
+
+from migrator.tests.models import SimpleObj
+from migrator.tests.base import BaseMockedCDMSApiTestCase
+
+
+class RevisionTestCase(BaseMockedCDMSApiTestCase):
+    @skip('Not supported out-of-the-box, to be implemented if needed')
+    def test_revert_deleted_object(self):
+        """
+        After deleting an object with revision, I should be able to revert to the last non-deleted version.
+
+        Unfortunately, the django-reversion code is a bit dirty at this point so the reversion.get_deleted(...)
+        method call does not work out of the box.
+
+        We would have to implement it manually when/if needed.
+        """
+        obj = SimpleObj.objects.skip_cdms().create(
+            name='test', cdms_pk='cdms-pk'
+        )
+        obj_id = obj.pk
+        self.reset_revisions()
+
+        self.assertEqual(Version.objects.count(), 0)
+        self.assertEqual(Revision.objects.count(), 0)
+
+        obj.save()
+        obj.delete()
+
+        # check cdms calls
+        self.assertEqual(self.mocked_cdms_api.get.call_count, 1)
+        self.assertEqual(self.mocked_cdms_api.update.call_count, 1)
+        self.assertEqual(self.mocked_cdms_api.delete.call_count, 1)
+        self.assertAPINotCalled(['list', 'create'])
+
+        self.mocked_cdms_api.reset_mock()
+
+        # check versions
+        self.assertEqual(Version.objects.count(), 1)
+        self.assertEqual(Revision.objects.count(), 1)
+
+        deleted_list = reversion.get_deleted(SimpleObj)
+        delete_version = deleted_list.get(id=obj_id)
+
+        # revert deleted version
+        delete_version.revert()
+
+        obj = SimpleObj.objects.skip_cdms().get(pk=obj_id)
+        self.assertEqual(obj.name, 'test')
+
+    def test_revert_to_previous_revision(self):
+        """
+        Saving an object in two different revisions and then reverting back to the first one should
+        make a single extra cdms call to update the object with the previous data.
+        """
+        obj = SimpleObj.objects.skip_cdms().create(
+            name='test', cdms_pk='cdms-pk'
+        )
+        self.reset_revisions()
+
+        # revision 1
+        obj.name = 'test old'
+        obj.save()
+
+        # revision 2
+        obj.name = 'test latest'
+        obj.save()
+
+        # check cdms calls
+        self.assertEqual(self.mocked_cdms_api.get.call_count, 2)
+        self.assertEqual(self.mocked_cdms_api.update.call_count, 2)
+        self.assertAPINotCalled(['list', 'create', 'delete'])
+
+        self.mocked_cdms_api.reset_mock()
+
+        # check versions
+        self.assertEqual(Version.objects.count(), 2)
+        self.assertEqual(Revision.objects.count(), 2)
+
+        version_list = reversion.get_for_object(obj)
+        self.assertEqual(len(version_list), 2)
+
+        version_old = version_list[1]
+        self.assertEqual(version_old.field_dict['name'], 'test old')
+
+        version_latest = version_list[0]
+        self.assertEqual(version_latest.field_dict['name'], 'test latest')
+
+        # revert to old version
+        version_old.revert()
+
+        obj = SimpleObj.objects.skip_cdms().get(pk=obj.pk)
+        self.assertEqual(obj.name, 'test old')
+
+        # check cdms update called
+        self.assertAPIUpdateCalled(
+            SimpleObj,
+            kwargs={
+                'guid': 'cdms-pk',
+                'data': {
+                    'Name': 'test old',
+                    'DateTimeField': None,
+                    'IntField': None,
+                    'SimpleId': 'cdms-pk',
+                    'FKField': None
+                }
+            }
+        )
+        self.assertAPINotCalled(['list', 'create', 'delete'])

--- a/data-hub-api/settings/base.py
+++ b/data-hub-api/settings/base.py
@@ -26,7 +26,9 @@ INSTALLED_APPS = [
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
-    'django.contrib.staticfiles'
+    'django.contrib.staticfiles',
+
+    'reversion'
 ]
 
 PROJECT_APPS = []

--- a/data-hub-api/settings/testing.py
+++ b/data-hub-api/settings/testing.py
@@ -2,7 +2,7 @@ from .base import *  # noqa
 
 
 INSTALLED_APPS += (
-    'migrator.tests.queries',
+    'migrator.tests',
 )
 
 CDMS_BASE_URL = 'https://testing.com'

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,3 +8,4 @@ psycopg2==2.6.1
 requests==2.9.1
 pyquery==1.2.11
 pytz==2016.2
+django-reversion==1.10.1


### PR DESCRIPTION
This adds django-reversion and a few basic tests to make sure that saving versions and reverting them back do not cause any unwanted cdms calls.

Versions are automatically saved transparently so that the dev doesn't need to do anything.
When local objects are refreshed from cdms, the change is saved as an extra revision.

Reverting deleted objects is not supported at the moment because of some poor django-reversion design choices. It's technically possibile to reimplement the method with custom logic but not needed for now.