### PR TITLE
Add docker files for jenkins unit tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+*.DS_Store
+*.py?
+*~
+__pycache__
+
+data-hub-api/settings/local.py
+data-hub-api/assets/
+static/
+docs/
+venv/
+env/

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ venv
 *.iws
 
 data-hub-api/settings/local.py
+reports
 
 # collect static output directory
 data-hub-api/assets/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.5.1
+
+RUN apt-get -y install \
+    gcc \
+    libc-dev \
+    libpq-dev
+
+RUN pip3 install -U setuptools pip wheel
+
+COPY ./requirements /requirements
+RUN pip3 install -r /requirements/jenkins.txt
+
+COPY . /app
+WORKDIR /app
+
+ADD . /app

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,17 @@
+// see https://dzone.com/refcardz/continuous-delivery-with-jenkins-workflow for tutorial
+// see https://documentation.cloudbees.com/docs/cookbook/_pipeline_dsl_keywords.html for DSL reference
+node {
+   // Mark the code checkout 'stage'....
+
+   stage 'Clean workspace'
+   deleteDir()
+   sh 'mkdir reports'
+
+   stage 'Unit test'
+   sh 'docker-compose -p data-hub-api-${BRANCH_NAME} up -d db'
+   sh 'docker-compose -p data-hub-api-${BRANCH_NAME} up django'
+   sh 'docker-compose -p data-hub-api-${BRANCH_NAME} stop'
+
+   stage 'Capture test results'
+   step([$class: 'JUnitResultArchiver', testResults: 'results/**/*.xml'])
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,9 +3,6 @@
 node {
    // Mark the code checkout 'stage'....
 
-   stage 'Prepare test'
-   sh 'mkdir reports'
-
    stage 'Unit test'
    sh 'docker-compose -p data-hub-api-${BRANCH_NAME} up -d db'
    sh 'docker-compose -p data-hub-api-${BRANCH_NAME} up django'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,8 +3,7 @@
 node {
    // Mark the code checkout 'stage'....
 
-   stage 'Clean workspace'
-   deleteDir()
+   stage 'Prepare test'
    sh 'mkdir reports'
 
    stage 'Unit test'
@@ -14,4 +13,7 @@ node {
 
    stage 'Capture test results'
    step([$class: 'JUnitResultArchiver', testResults: 'results/**/*.xml'])
+
+   stage 'Clean workspace'
+   deleteDir()
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,9 @@
 node {
    // Mark the code checkout 'stage'....
 
+   stage 'Checkout'
+   checkout scm
+
    stage 'Unit test'
    sh 'docker-compose -p data-hub-api-${BRANCH_NAME} up -d db'
    sh 'docker-compose -p data-hub-api-${BRANCH_NAME} up django'

--- a/data-hub-api/settings/jenkins.py
+++ b/data-hub-api/settings/jenkins.py
@@ -1,0 +1,19 @@
+from .base import *  # noqa
+
+INSTALLED_APPS += (
+    'django_jenkins',
+)
+
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': 'data-hub-api',
+        'USER': os.environ['DB_USERNAME'],
+        'PASSWORD': os.environ.get('DB_PASSWORD', ''),
+        'HOST': os.environ.get('DB_HOST', ''),
+        'PORT': '',
+    }
+}
+
+TEST_RUNNER = 'django_jenkins.runner.CITestSuiteRunner'

--- a/data-hub-api/settings/production.py
+++ b/data-hub-api/settings/production.py
@@ -3,7 +3,7 @@ import os
 
 
 DEBUG = False
-TEMPLATES['OPTIONS']['debug'] = DEBUG
+TEMPLATES[0]['OPTIONS']['debug'] = DEBUG
 
 SECRET_KEY = os.environ["SECRET_KEY"]
 
@@ -19,7 +19,7 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
         'NAME': 'data-hub-api',
-        'USER': os.environ['DB_USER'],
+        'USER': os.environ['DB_USERNAME'],
         'PASSWORD': os.environ.get('DB_PASSWORD', ''),
         'HOST': os.environ.get('DB_HOST', ''),
         'PORT': '',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: "2"
+
+services:
+  db:
+    image: postgres
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+
+  django:
+    build: .
+    command: ./jenkins/wait-for-it.sh db:5432 -- ./manage.py test --verbosity=2
+    links:
+      - db
+    volumes:
+      - ./reports:/app/reports
+    environment:
+      DJANGO_SECRET_KEY: unit-tests
+      DJANGO_SETTINGS_MODULE: data-hub-api.settings.jenkins
+      DB_NAME: data-hub-api
+      DB_USERNAME: postgres
+      DB_PASSWORD: postgres
+      DB_HOST: db
+      DB_PORT: 5432

--- a/jenkins/wait-for-it.sh
+++ b/jenkins/wait-for-it.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+#   Use this script to test if a given TCP host/port are available
+
+cmdname=$(basename $0)
+
+echoerr() { if [[ $QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $TIMEOUT -gt 0 ]]; then
+        echoerr "$cmdname: waiting $TIMEOUT seconds for $HOST:$PORT"
+    else
+        echoerr "$cmdname: waiting for $HOST:$PORT without a timeout"
+    fi
+    start_ts=$(date +%s)
+    while :
+    do
+        (echo > /dev/tcp/$HOST/$PORT) >/dev/null 2>&1
+        result=$?
+        if [[ $result -eq 0 ]]; then
+            end_ts=$(date +%s)
+            echoerr "$cmdname: $HOST:$PORT is available after $((end_ts - start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $QUIET -eq 1 ]]; then
+        timeout $TIMEOUT $0 --quiet --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    else
+        timeout $TIMEOUT $0 --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    fi
+    PID=$!
+    trap "kill -INT -$PID" INT
+    wait $PID
+    RESULT=$?
+    if [[ $RESULT -ne 0 ]]; then
+        echoerr "$cmdname: timeout occurred after waiting $TIMEOUT seconds for $HOST:$PORT"
+    fi
+    return $RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        hostport=(${1//:/ })
+        HOST=${hostport[0]}
+        PORT=${hostport[1]}
+        shift 1
+        ;;
+        --child)
+        CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        STRICT=1
+        shift 1
+        ;;
+        -h)
+        HOST="$2"
+        if [[ $HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        PORT="$2"
+        if [[ $PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        TIMEOUT="$2"
+        if [[ $TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        CLI="$@"
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$HOST" == "" || "$PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+TIMEOUT=${TIMEOUT:-15}
+STRICT=${STRICT:-0}
+CHILD=${CHILD:-0}
+QUIET=${QUIET:-0}
+
+if [[ $CHILD -gt 0 ]]; then
+    wait_for
+    RESULT=$?
+    exit $RESULT
+else
+    if [[ $TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        RESULT=$?
+    else
+        wait_for
+        RESULT=$?
+    fi
+fi
+
+if [[ $CLI != "" ]]; then
+    if [[ $RESULT -ne 0 && $STRICT -eq 1 ]]; then
+        echoerr "$cmdname: strict mode, refusing to execute subprocess"
+        exit $RESULT
+    fi
+    exec $CLI
+else
+    exit $RESULT
+fi

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,5 +1,4 @@
 -r base.txt
 
-mock==1.3.0
 model-mommy==1.2.6
 responses==0.5.1


### PR DESCRIPTION
This PR is open to test Jenkins and it's still WIP but in good shape.

Summary:
- the `Dockerfile` defines the image for the unit tests. I would like to move it to the *jenkins* folder if docker stops complaining
- the `docker-compose.yml` defines the env for the unit tests. I would like to move this as well to the *jenkins* folder if docker stops complaining
- the `Jenkinsfile` defines a basic Jenkins Pipeline

To run unit tests in Jenkins, you would just need to run 
`docker-compose -p data-hub-api-<PR-NAME> up -d db`
`docker-compose -p data-hub-api-<PR-NAME> up -d django`
`docker-compose -p data-hub-api-<PR-NAME> stop  # to stop the db`

and inspect the *reports* folder. Many of these can run in parallel without problems.

I don't particularly like the *jenkins/wait-for-it.sh* but apparently it's common practice for waiting until the db is ready.
I also don't like 3 commands and especially the last one which stops the db but I'm not sure we could do all with only one command.

All in all, it's clean and a lot better than a bash script.