### PR TITLE
Linting tweaks

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,7 @@
+[settings]
+include_trailing_comma=True
+line_length=79
+multi_line_output=3
+not_skip=__init__.py
+skip_glob=**/migrations/*.py
+# verbose=true  # Use this for debugging

--- a/data-hub-api/tox.ini
+++ b/data-hub-api/tox.ini
@@ -1,4 +1,3 @@
 [flake8]
 exclude = */migrations/
 max-line-length = 119
-ignore = N801,N802,N806


### PR DESCRIPTION
Two adjustments to linting for conversation.

* Remove ignored pep8 errors.
* Propose an isort config. This isn't wired into CI yet, it could just be used for files that are touched going forwards.

Let me know thoughts.