### PR TITLE
jenkins2.0 vars

### DIFF
--- a/data-hub-api/apps/cdms_api/tests/test_env.py
+++ b/data-hub-api/apps/cdms_api/tests/test_env.py
@@ -1,18 +1,149 @@
+import os
+
 from django.conf import settings
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 
-class TestEnv(TestCase):
+class EnvSettingsAssertion:
 
-    def test_happy(self):
+    def assertSettingEnvExpected(self, environment_name, django_name, default):
         """
-        Default values for settings are loaded
-
-        This serves to test the default fall through for these settings since
-        they can be overridden by the environment.
+        Given a pair of environment variable and Django setting names and a
+        default value, assert that Django loaded the expected value into the
+        Django setting.
         """
-        self.assertEqual(settings.CDMS_BASE_URL, 'https://example.com')
-        self.assertEqual(settings.CDMS_USERNAME, 'username')
-        self.assertEqual(settings.CDMS_PASSWORD, 'password')
-        with self.assertRaises(AttributeError):
-            settings.TEST_INTEGRATION
+        django_value = getattr(settings, django_name)
+
+        try:
+            expected_value = os.environ[environment_name]
+        except KeyError:
+            expected_value = default
+
+        self.assertEqual(django_value, expected_value)
+
+
+class TestEnv(TestCase, EnvSettingsAssertion):
+    """
+    Asserts that default values for settings are loaded if no envvar is set. In
+    the case that the suite is run when there *is* an envvar, then the expected
+    value is checked.
+
+    This serves to test the default fall through for these settings since they
+    can be overridden by the environment.
+    """
+
+    def test_CDMS_USERNAME(self):
+        """
+        CDMS_USERNAME setting is loaded as expected
+        """
+        self.assertSettingEnvExpected(
+            environment_name='DJANGO__CDMS_USERNAME',
+            django_name='CDMS_USERNAME',
+            default='username',
+        )
+
+    def test_CDMS_PASSWORD(self):
+        """
+        CDMS_PASSWORD setting is loaded as expected
+        """
+        self.assertSettingEnvExpected(
+            environment_name='DJANGO__CDMS_PASSWORD',
+            django_name='CDMS_PASSWORD',
+            default='password',
+        )
+
+    def test_CDMS_BASE_URL(self):
+        """
+        CDMS_BASE_URL setting is loaded as expected
+        """
+        self.assertSettingEnvExpected(
+            environment_name='DJANGO__CDMS_BASE_URL',
+            django_name='CDMS_BASE_URL',
+            default='https://example.com',
+        )
+
+
+class TestAssertSettingsEnvExpected(TestCase, EnvSettingsAssertion):
+    """
+    Given an environment variable '__ENV_NAME__'
+    Given a Django setting '__DJANGO_NAME__'
+    Given a default value for the Django setting of '__DEFAULT__'
+
+    Then test the following states:
+
+    ----------------+-------------------+-----------
+     __ENV_NAME__   | __DJANGO_NAME__   | Result
+    ----------------+-------------------+-----------
+     None           | '__DEFAULT__'     | Pass
+     None           | '__OTHER__'       | Fail
+     '__VALUE__'    | '__DEFAULT__'     | Fail
+     '__VALUE__'    | '__VALUE__'       | Pass
+     '__VALUE__'    | '__OTHER__'       | Fail
+    ----------------+-------------------+-----------
+    """
+
+    def tearDown(self):
+        """
+        Remove any left over envvar otherwise it'll hang over to the next test
+        """
+        try:
+            del(os.environ['__ENV_NAME__'])
+        except KeyError:
+            pass
+        super().tearDown()
+
+    def test_set_up(self):
+        """
+        setUp: assertSettingEnvExpected tests start with no env var
+        """
+        self.assertFalse('__ENV_NAME__' in os.environ)
+
+    @override_settings(__DJANGO_NAME__='__DEFAULT__')
+    def test_none_default(self):
+        """
+        assertSettingEnvExpected: No envvar, Django setting is default value
+        """
+
+        self.assertSettingEnvExpected('__ENV_NAME__', '__DJANGO_NAME__', '__DEFAULT__')
+
+    @override_settings(__DJANGO_NAME__='__OTHER__')
+    def test_none_other(self):
+        """
+        assertSettingEnvExpected: No envvar, Django setting other value
+        """
+        try:
+            del(os.environ['__ENV_NAME__'])
+        except KeyError:
+            pass
+
+        with self.assertRaises(AssertionError):
+            self.assertSettingEnvExpected('__ENV_NAME__', '__DJANGO_NAME__', '__DEFAULT__')
+
+    @override_settings(__DJANGO_NAME__='__DEFAULT__')
+    def test_value_default(self):
+        """
+        assertSettingEnvExpected: envvar has value, setting is default
+        """
+        os.environ['__ENV_NAME__'] = '__VALUE__'
+
+        with self.assertRaises(AssertionError):
+            self.assertSettingEnvExpected('__ENV_NAME__', '__DJANGO_NAME__', '__DEFAULT__')
+
+    @override_settings(__DJANGO_NAME__='__VALUE__')
+    def test_value_value(self):
+        """
+        assertSettingEnvExpected: envvar has value, setting is value
+        """
+        os.environ['__ENV_NAME__'] = '__VALUE__'
+
+        self.assertSettingEnvExpected('__ENV_NAME__', '__DJANGO_NAME__', '__DEFAULT__')
+
+    @override_settings(__DJANGO_NAME__='__OTHER__')
+    def test_value_other(self):
+        """
+        assertSettingEnvExpected: envvar has value, setting is other
+        """
+        os.environ['__ENV_NAME__'] = '__VALUE__'
+
+        with self.assertRaises(AssertionError):
+            self.assertSettingEnvExpected('__ENV_NAME__', '__DJANGO_NAME__', '__OTHER__')

--- a/data-hub-api/apps/cdms_api/tests/test_env.py
+++ b/data-hub-api/apps/cdms_api/tests/test_env.py
@@ -62,6 +62,20 @@ class TestEnv(TestCase, EnvSettingsAssertion):
             default='https://example.com',
         )
 
+    def test_TEST_INTEGRATION(self):
+        """
+        TEST_INTEGRATION setting is loaded as expected
+
+        Slightly different test required because TEST_INTEGRATION uses a truthy
+        value.
+        """
+        try:
+            value = bool(os.environ['DJANGO__TEST_INTEGRATION'])
+            self.assertEqual(settings.TEST_INTEGRATION, value)
+        except KeyError:
+            with self.assertRaises(AttributeError):
+                settings.TEST_INTEGRATION
+
 
 class TestAssertSettingsEnvExpected(TestCase, EnvSettingsAssertion):
     """

--- a/data-hub-api/apps/cdms_api/tests/test_env.py
+++ b/data-hub-api/apps/cdms_api/tests/test_env.py
@@ -97,6 +97,59 @@ class TestEnv(TestCase, EnvSettingsAssertion):
             with self.assertRaises(AttributeError):
                 settings.TEST_INTEGRATION
 
+    def test_DATABASE_default_NAME(self):
+        """
+        DATABASES.default.NAME is loaded as expected
+
+        Slightly dirty because it's creating the test database name and testing
+        against that by prefixing 'test_'
+        """
+        self.assertSettingEnvExpected(
+            environment_name='DJANGO__DB_NAME',
+            django_name='DATABASES.default.NAME',
+            default='test_data-hub-api',
+        )
+
+    def test_DATABASE_default_USERNAME(self):
+        """
+        DATABASES.default.USERNAME is loaded as expected
+        """
+        self.assertSettingEnvExpected(
+            environment_name='DJANGO__DB_USERNAME',
+            django_name='DATABASES.default.USER',
+            default='',
+        )
+
+    def test_DATABASE_default_PASSWORD(self):
+        """
+        DATABASES.default.NAME is loaded as expected
+        """
+        self.assertSettingEnvExpected(
+            environment_name='DJANGO__DB_PASSWORD',
+            django_name='DATABASES.default.PASSWORD',
+            default='',
+        )
+
+    def test_DATABASE_default_HOST(self):
+        """
+        DATABASES.default.HOST is loaded as expected
+        """
+        self.assertSettingEnvExpected(
+            environment_name='DJANGO__DB_HOST',
+            django_name='DATABASES.default.HOST',
+            default='',
+        )
+
+    def test_DATABASE_default_PORT(self):
+        """
+        DATABASES.default.PORT is loaded as expected
+        """
+        self.assertSettingEnvExpected(
+            environment_name='DJANGO__DB_PORT',
+            django_name='DATABASES.default.PORT',
+            default='5432',
+        )
+
 
 class TestAssertSettingsEnvExpected(TestCase, EnvSettingsAssertion):
     """

--- a/data-hub-api/settings/testing.py
+++ b/data-hub-api/settings/testing.py
@@ -30,7 +30,7 @@ DATABASES = {
         'NAME': os.environ.get('DJANGO__DB_NAME', 'data-hub-api'),
         'USER': os.environ.get('DJANGO__DB_USERNAME', ''),
         'PASSWORD': os.environ.get('DJANGO__DB_PASSWORD', ''),
-        'HOST': os.environ.get('DJANGO__DB_HOST', 'db'),
+        'HOST': os.environ.get('DJANGO__DB_HOST', ''),
         'PORT': os.environ.get('DJANGO__DB_PORT', '5432'),
     }
 }


### PR DESCRIPTION
Updating the envvars for Jenkins, while maintaining the local and CircleCI runs.

* Fix the default database name to be `''` so that tests run on Circle
* Add env var testing so that when settings should be default they are asserted as default and when vars are overridden from environment, then those expected values are used too.

*Side effect*: Running tests locally should now use env vars rather than the `testing-local` settings file.

@nusnewob - please test this runs in Jenkins :smile: 